### PR TITLE
use jsdelivr instead of unpkg to import PRCI

### DIFF
--- a/privacy_portal/index.html
+++ b/privacy_portal/index.html
@@ -29,7 +29,7 @@
   <script defer data-domain="dogfood.blindnet.io" src="https://plausible.io/js/plausible.js"></script>
 
   <!-- devkit -->
-  <script src="https://unpkg.com/@blindnet/prci/dist/index.core.min.js?module" type="module"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@blindnet/prci/dist/index.all.min.js" type="module"></script>
 
   <!--auth0-->
   <script src="https://cdn.auth0.com/js/auth0-spa-js/1.22.5/auth0-spa-js.production.js"></script>


### PR DESCRIPTION
Uses jsdelivr with our index.all.min link to import the PRCI, fixes the issue we had we unkpkg.