### PR TITLE
always use latest version of PRCI

### DIFF
--- a/privacy_portal/index.html
+++ b/privacy_portal/index.html
@@ -29,7 +29,7 @@
   <script defer data-domain="dogfood.blindnet.io" src="https://plausible.io/js/plausible.js"></script>
 
   <!-- devkit -->
-  <script src="https://cdn.jsdelivr.net/npm/@blindnet/prci/dist/index.all.min.js" type="module"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@blindnet/prci@latest/dist/index.all.min.js" type="module"></script>
 
   <!--auth0-->
   <script src="https://cdn.auth0.com/js/auth0-spa-js/1.22.5/auth0-spa-js.production.js"></script>


### PR DESCRIPTION
Forces jsdelivr to load the latest version of the PRCI, which it [sometimes](https://stackoverflow.com/questions/69148904/difference-in-jsdelivr-url-with-without-latest) won't.